### PR TITLE
keep paths relative to the current user

### DIFF
--- a/ajax/getimages.php
+++ b/ajax/getimages.php
@@ -54,12 +54,15 @@ foreach ($images as &$image) {
 	if (substr($image['path'], 0, 8) === '/Shared/') {
 		$owner = \OC\Files\Filesystem::getOwner($image['path']);
 		$users[$owner] = $owner;
+		$path = substr($image['path'], 7);
+	} else {
+		$owner = $user;
+		$path = $image['path'];
 	}
-	$path = $user . $image['path'];
 	if (strpos($path, DIRECTORY_SEPARATOR . ".")) {
 		continue;
 	}
-	$image['path'] = $user . $image['path'];
+	$image['path'] = $owner . $path;
 }
 
 $displayNames = array();
@@ -77,4 +80,4 @@ foreach ($images as $image) {
 }
 
 OCP\JSON::setContentTypeHeader();
-echo json_encode(array('images' => $result, 'users' => $users, 'displayNames' => $displayNames));
+echo json_encode(array('images' => $result, 'users' => array_values($users), 'displayNames' => $displayNames));

--- a/ajax/getimages.php
+++ b/ajax/getimages.php
@@ -48,6 +48,7 @@ OCP\JSON::checkAppEnabled('gallery');
 
 $images = \OCP\Files::searchByMime('image');
 $user = \OCP\User::getUser();
+$result = array();
 
 foreach ($images as &$image) {
 	// we show shared images another way
@@ -62,7 +63,7 @@ foreach ($images as &$image) {
 	if (strpos($path, DIRECTORY_SEPARATOR . ".")) {
 		continue;
 	}
-	$image['path'] = $owner . $path;
+	$result[] = $owner . $path;
 }
 
 $displayNames = array();
@@ -72,11 +73,6 @@ foreach ($users as $user) {
 
 function startsWith($haystack, $needle) {
 	return !strncmp($haystack, $needle, strlen($needle));
-}
-
-$result = array();
-foreach ($images as $image) {
-	$result[] = $image['path'];
 }
 
 OCP\JSON::setContentTypeHeader();

--- a/ajax/getimages.php
+++ b/ajax/getimages.php
@@ -52,43 +52,14 @@ $user = \OCP\User::getUser();
 foreach ($images as &$image) {
 	// we show shared images another way
 	if (substr($image['path'], 0, 8) === '/Shared/') {
-		continue;
+		$owner = \OC\Files\Filesystem::getOwner($image['path']);
+		$users[$owner] = $owner;
 	}
 	$path = $user . $image['path'];
 	if (strpos($path, DIRECTORY_SEPARATOR . ".")) {
 		continue;
 	}
 	$image['path'] = $user . $image['path'];
-}
-
-$shared = array();
-$sharedSources = OCP\Share::getItemsSharedWith('file');
-$users = array();
-foreach ($sharedSources as $sharedSource) {
-	$owner = $sharedSource['uid_owner'];
-	if (array_search($owner, $users) === false) {
-		$users[] = $owner;
-	}
-	\OC\Files\Filesystem::initMountPoints($owner);
-	$ownerView = new \OC\Files\View('/' . $owner . '/files');
-	$path = $ownerView->getPath($sharedSource['item_source']);
-	if ($path) {
-		$shareName = basename($path);
-		$shareView = new \OC\Files\View('/' . $owner . '/files' . $path);
-		if ($shareView->is_dir('')) {
-			$sharedImages = $shareView->searchByMime('image');
-			foreach ($sharedImages as $sharedImage) {
-				// set the file_source in the path so we can get the original shared folder later
-				$sharedImage['path'] = $owner . '/' . $sharedSource['file_source'] . '/' . $shareName . $sharedImage['path'];
-				$images[] = $sharedImage;
-			}
-		} else {
-			$sharedImage = $shareView->getFileInfo('');
-			$sharedImage['path'] = $owner . '/' . $sharedSource['file_source'] . '/' . $shareName;
-			$images[] = $sharedImage;
-		}
-
-	}
 }
 
 $displayNames = array();

--- a/ajax/image.php
+++ b/ajax/image.php
@@ -8,59 +8,29 @@
 
 OCP\JSON::checkAppEnabled('gallery');
 
-list($token, $img) = explode('/', $_GET['file'], 2);
-$linkItem = \OCP\Share::getShareByToken($token);
+list($owner, $img) = explode('/', $_GET['file'], 2);
+$linkItem = \OCP\Share::getShareByToken($owner);
 if (is_array($linkItem) && isset($linkItem['uid_owner'])) {
 	// seems to be a valid share
 	$rootLinkItem = \OCP\Share::resolveReShare($linkItem);
-	$owner = $rootLinkItem['uid_owner'];
-	OCP\JSON::checkUserExists($owner);
+	$img = trim($rootLinkItem['file_target'] . '/' . $img);
+	$user = $rootLinkItem['uid_owner'];
+	OCP\JSON::checkUserExists($user);
 	OC_Util::tearDownFS();
-	OC_Util::setupFS($owner);
+	OC_Util::setupFS($user);
 	\OC_User::setIncognitoMode(true);
 } else {
 	OCP\JSON::checkLoggedIn();
+	$user = OCP\User::getUser();
 
-	list($owner, $img) = explode('/', $_GET['file'], 2);
-	if ($owner !== OCP\User::getUser()) {
-		OC_Util::tearDownFS();
-		OCP\JSON::checkUserExists($owner);
-		OC_Util::setupFS($owner);
-		$view = new \OC\Files\View('/' . $owner . '/files');
-		//images have 1 slashes, albums at least 2
-		if (substr_count($img, '/') === 1) {
-			list($folderId, $img) = explode('/', $img, 2);
-		} else {
-			// second part is the (duplicated) share name
-			list($folderId, , $img) = explode('/', $img, 3);
-		}
-		$shareInfo = \OCP\Share::getItemSharedWithBySource('file', $folderId);
-		if ($shareInfo) {
-			$sharedFolder = $view->getPath($folderId);
-			if ($sharedFolder and $view->is_dir($sharedFolder)) {
-				$img = $sharedFolder . '/' . $img;
-			} elseif ($sharedFolder) {
-				$img = $sharedFolder;
-			} else {
-				\OC_Response::setStatus(404);
-				exit;
-			}
-		} else {
-			\OC_Response::setStatus(403);
-			exit;
-		}
+	if ($owner !== $user) {
+		$img = 'Shared/' . $img;
 	}
 }
 
 session_write_close();
 
-$ownerView = new \OC\Files\View('/' . $owner . '/files');
-
-if (is_array($linkItem) && isset($linkItem['uid_owner'])) {
-	// prepend path to share
-	$path = $ownerView->getPath($linkItem['file_source']);
-	$img = $path.'/'.$img;
-}
+$ownerView = new \OC\Files\View('/' . $user . '/files');
 
 $mime = $ownerView->getMimeType($img);
 list($mimePart,) = explode('/', $mime);

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -293,10 +293,6 @@ Gallery.view.viewAlbum = function (albumPath) {
 	crumbs = albumPath.split('/');
 	//first entry is username
 	path = crumbs.splice(0, 1);
-	//remove shareid
-	if (path[0] !== OC.currentUser && path[0] !== $('#gallery').data('token')) {
-		path += '/' + crumbs.splice(0, 1);
-	}
 	for (i = 0; i < crumbs.length; i++) {
 		if (crumbs[i]) {
 			path += '/' + crumbs[i];

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -333,7 +333,6 @@ Gallery.view.showUsers = function () {
 				$('#gallery').append(head);
 				for (j = 0; j < subAlbums.length; j++) {
 					album = subAlbums[j];
-					album = Gallery.subAlbums[album][0];//first level sub albums is share source id
 					Gallery.view.addAlbum(album);
 					Gallery.view.element.append(' '); //add a space for justify
 				}

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -15,10 +15,9 @@ Gallery.fillAlbums = function () {
 	var def = new $.Deferred();
 	var token = $('#gallery').data('token');
 	$.getJSON(OC.filePath('gallery', 'ajax', 'getimages.php'), {token: token}).then(function (data) {
-		var albumPath, i, imagePath, parent, path;
 		Gallery.users = data.users;
 		Gallery.displayNames = data.displayNames;
-		for (i = 0; i < data.images.length; i++) {
+		for (var i = 0; i < data.images.length; i++) {
 			Gallery.images.push(data.images[i]);
 		}
 		Gallery.fillAlbums.fill(Gallery.albums, Gallery.images);
@@ -37,7 +36,7 @@ Gallery.fillAlbums.fill = function (albums, images) {
 		albumPath = OC.dirname(imagePath);
 		albumPathParts = albumPath.split('/');
 		//group single share images in a single album
-		if (OC.currentUser && albumPathParts.length === 2 && albumPathParts[0] !== OC.currentUser) {
+		if (OC.currentUser && albumPathParts.length === 1 && albumPathParts[0] !== OC.currentUser) {
 			albumPath = albumPathParts[0];
 		}
 		if (!albums[albumPath]) {
@@ -162,7 +161,7 @@ Gallery.view.addImage = function (image) {
 };
 
 Gallery.view.addAlbum = function (path, name) {
-	var link, image, label, thumbs, thumb;
+	var link, label, thumbs, thumb;
 	name = name || OC.basename(path);
 	if (Gallery.view.cache[path]) {
 		thumbs = Gallery.view.addAlbum.thumbs[path];
@@ -319,10 +318,13 @@ Gallery.view.pushBreadCrumb = function (text, path) {
 };
 
 Gallery.view.showUsers = function () {
-	var i, j, k, user, head, subAlbums, album, singleImages;
+	var i, j, user, head, subAlbums, album, singleImages;
+	console.log('asdasdasd');
 	for (i = 0; i < Gallery.users.length; i++) {
 		singleImages = [];
 		user = Gallery.users[i];
+		console.log('asd');
+		console.log(user);
 		subAlbums = Gallery.subAlbums[user];
 		if (subAlbums) {
 			if (subAlbums.length > 0) {
@@ -378,7 +380,7 @@ $(document).ready(function () {
 		$(window).scrollTop(Gallery.scrollLocation);
 		var albumParts = Gallery.currentAlbum.split('/');
 		//not an album bit a single shared image, go back to the root
-		if (OC.currentUser && albumParts.length === 2 && albumParts[0] !== OC.currentUser) {
+		if (OC.currentUser && albumParts.length === 1 && albumParts[0] !== OC.currentUser) {
 			Gallery.currentAlbum = OC.currentUser;
 		}
 		location.hash = Gallery.currentAlbum;


### PR DESCRIPTION
keep paths relative to the current user, otherwise encryption will not work.

cc @PVince81 This basically works but it breaks the way we show shared galleries, maybe you can have a look at it? If I understand the code correctly all the logic should be in apps/gallery/js/gallery.js Thanks!

fix for https://github.com/owncloud/core/issues/7116
