### PR TITLE
mobile: use also for logged-in pictures app. Blocked by core work still

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -6,13 +6,21 @@
 	position: absolute !important;
 }
 
+/* adjust share dropdown */
+#dropdown {
+	margin-right: 0 !important;
+}
+
 /* smaller images for smaller screens, fit 2 to width */
 #gallery > a > img,
-#gallery > a,
-#gallery > a.album,
 #gallery > a.image > img {
-	max-height: 130px;
-	max-width: 130px;
+	max-height: 100%;
+	max-width: 100%;
+}
+#gallery > a,
+#gallery > a.album {
+	max-height: 100px;
+	max-width: 100px;
 }
 
 

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -4,6 +4,7 @@
 #header,
 #controls {
 	position: absolute !important;
+	top: 0;
 }
 
 /* adjust share dropdown */

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -1,4 +1,4 @@
-@media only screen and (max-width: 600px) {
+@media only screen and (max-width: 768px) {
 
 /* make header and controls bar scroll up for more view of content on small screens */
 #header,

--- a/css/styles.css
+++ b/css/styles.css
@@ -122,8 +122,7 @@ button.share {
 }
 
 #dropdown {
-	top: 6.4em;
-	position: fixed;
+	top: 43px;
 	right: 0;
 	margin-right: 0;
 	border-bottom-right-radius: 0;

--- a/index.php
+++ b/index.php
@@ -10,9 +10,10 @@ OCP\User::checkLoggedIn();
 OCP\App::checkAppEnabled('gallery');
 OCP\App::setActiveNavigationEntry('gallery_index');
 
+OCP\Util::addStyle('gallery', 'styles');
+OCP\Util::addStyle('gallery', 'mobile');
 OCP\Util::addScript('gallery', 'gallery');
 OCP\Util::addScript('gallery', 'thumbnail');
-OCP\Util::addStyle('gallery', 'styles');
 
 $tmpl = new OCP\Template('gallery', 'index', 'user');
 $tmpl->printPage();


### PR DESCRIPTION
This needs https://github.com/owncloud/core/pull/7724 to be merged first and look good, mainly because of the app navigation.

As a basic first step, I just adapted the styles for the mobile share page. Please check @DeepDiver1975 @PVince81 @karlitschek
