### PR TITLE
Fix viewing gallery with non-ASCII symbols in directory name

### DIFF
--- a/js/gallery.js
+++ b/js/gallery.js
@@ -358,8 +358,8 @@ $(document).ready(function () {
 		var i = images.index(this),
 			image = $this.data('path');
 		event.preventDefault();
-		if (location.hash !== image) {
-			location.hash = image;
+		if (location.hash !== encodeURI(image)) {
+			location.hash = encodeURI(image);
 			Thumbnail.paused = true;
 			Slideshow.start(images, i);
 		}
@@ -378,13 +378,13 @@ $(document).ready(function () {
 		if (OC.currentUser && albumParts.length === 1 && albumParts[0] !== OC.currentUser) {
 			Gallery.currentAlbum = OC.currentUser;
 		}
-		location.hash = Gallery.currentAlbum;
+		location.hash = encodeURI(Gallery.currentAlbum);
 		Thumbnail.concurrent = 3;
 	};
 });
 
 window.onhashchange = function () {
-	var album = location.hash.substr(1);
+	var album = decodeURI(location.hash).substr(1);
 	if (!album) {
 		album = OC.currentUser;
 	}


### PR DESCRIPTION
This commit fix bug when viewing gallery with non-ASCII symbols in directory name. In this case some browsers (Safari, in my case) redirect user to wrong (nonexistent) path.

Example: «Свадьба» converts to «C204L10» in location.hash.
