### PR TITLE
Prevent ugly select bar to appear when touching slideshow

### DIFF
--- a/css/slideshow.css
+++ b/css/slideshow.css
@@ -1,4 +1,3 @@
-
 #slideshow {
 	position: fixed;
 	left: 0;
@@ -9,6 +8,12 @@
 	display: none;
 	background-color: black;
 	background-position: center center;
+	-webkit-touch-callout: none;
+	-webkit-user-select: none;
+	-khtml-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
 }
 
 #slideshow>img {


### PR DESCRIPTION
While testing the slideshow I try to switch to the next pic by touching the screen (my laptop has a touchscreen, yay) and an ugly blue selection appear because I happened to drag the cursor a bit.

Could happen on tablets as well.

This PR prevents a select highlight to appear when dragging/touchsliding inside the slideshow.

@DeepDiver1975 @owncloud/designers @icewind1991 
