### PR TITLE
Rotate thumbnail when encryption is enabled

### DIFF
--- a/lib/thumbnail.php
+++ b/lib/thumbnail.php
@@ -58,15 +58,22 @@ class Thumbnail {
 	private function create($imagePath, $square) {
 		$galleryDir = \OC_User::getHome($this->user) . '/gallery/' . $this->user . '/';
 		$dir = dirname($imagePath);
-		if (!$this->view->file_exists($imagePath)) {
-			return;
+		$fileInfo = $this->view->getFileInfo($imagePath);
+		if(!$fileInfo) {
+			return false;
 		}
 		if (!is_dir($galleryDir . $dir)) {
 			mkdir($galleryDir . $dir, 0755, true);
 		}
-		$local = $this->view->getLocalFile($imagePath);
+
 		$this->image = new \OCP\Image();
-		$this->image->loadFromFile($local);
+		// check if file is encrypted
+		if($fileInfo['encrypted'] === true) {
+			$fileName = $this->view->toTmpFile($imagePath);
+		} else {
+			$fileName = $this->view->getLocalFile($imagePath);
+		}
+		$this->image->loadFromFile($fileName);
 		if ($this->image->valid()) {
 			$this->image->fixOrientation();
 			if ($square) {


### PR DESCRIPTION
When a picture is encrypted, save it to a temporary file first so that
the PHP function for rotation can access it as file.

I'm not too thrilled about this solution as it involves temporary files.
Besides, inside the slideshow the pic is still rotated, but a recent PR that renders the slideshow with thumbnails might fix that.

Obviously I'd prefer having a library that can read directly from streams.

Such issue also exists in core for the small previews.

Let's discuss @DeepDiver1975 @georgehrke @schiesbn 
