### PR TITLE
use notification to show template loading error, refs #1282

### DIFF
--- a/js/slideshow.js
+++ b/js/slideshow.js
@@ -334,7 +334,7 @@ $(document).ready(function () {
 		}
 	})
 		.fail(function () {
-			alert(t('core', 'Error loading slideshow template'));
+			OC.Notification.show(t('core', 'Error loading slideshow template'));
 		});
 
 


### PR DESCRIPTION
listening to @jancborchardt pleas. Still think the root issue has to do with .htaccess and us not allowing html templates.
