### PR TITLE
fix position of pause icon

### DIFF
--- a/css/slideshow.css
+++ b/css/slideshow.css
@@ -90,8 +90,8 @@
 
 #slideshow > .progress {
 	position: fixed;
-	bottom: 10px;
-	right: 10px;
+	bottom: 13px;
+	right: 13px;
 	background-position: 0 100%;
 	width: 32px;
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=30)";


### PR DESCRIPTION
Before
![pause-icon-before](https://cloud.githubusercontent.com/assets/245432/3698910/fbf02520-13ca-11e4-8f3d-b121382d922b.png)
After
![pause-icon-after](https://cloud.githubusercontent.com/assets/245432/3698912/fd439c4a-13ca-11e4-9fa7-8d72509f679b.png)

Needs backport to stable7 cc @owncloud/designers @karlitschek 
