### PR TITLE
show loading spinner instead of static 'Loading' text

### DIFF
--- a/js/gallery.js
+++ b/js/gallery.js
@@ -206,13 +206,13 @@ Gallery.showEmpty = function () {
 Gallery.showLoading = function () {
 	$('#emptycontent').addClass('hidden');
 	$('#controls').removeClass('hidden');
-	$('#loading').removeClass('hidden');
+	$('#content').addClass('icon-loading');
 };
 
 Gallery.showNormal = function () {
 	$('#emptycontent').addClass('hidden');
 	$('#controls').removeClass('hidden');
-	$('#loading').addClass('hidden');
+	$('#content').removeClass('icon-loading');
 };
 
 Gallery.slideShow = function (images, startImage, autoPlay) {

--- a/templates/index.php
+++ b/templates/index.php
@@ -9,6 +9,5 @@
 <div id="gallery" class="hascontrols"></div>
 
 <div id="emptycontent" class="hidden"><?php p($l->t("No pictures found! If you upload pictures in the files app, they will be displayed here.")); ?></div>
-<div id="loading" class="hidden"><?php p($l->t("Loading...")); ?></div>
 
 <input type="hidden" name="allowShareWithLink" id="allowShareWithLink" value="yes" />


### PR DESCRIPTION
Make it consistent with other apps.

Please review @libasys @icewind1991 @owncloud/designers
