### PR TITLE
Remove not needed Classes

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -39,10 +39,3 @@ OCP\Util::addScript('gallery', 'slideshow');
 OCP\Util::addScript('gallery', 'public');
 OCP\Util::addStyle('gallery', 'slideshow');
 
-// register filesystem hooks to update thumbnails
-OCP\Util::connectHook('OC_Filesystem', 'post_write', 'OCA\Gallery\Thumbnail', 'writeHook');
-OCP\Util::connectHook('OC_Filesystem', 'post_delete', 'OCA\Gallery\Thumbnail', 'removeHook');
-
-// register share backend
-OCP\Share::registerBackend('picture', 'OCA\Gallery\Share\Picture', null, array('gif', 'jpeg', 'jpg', 'png', 'svg', 'svgz'));
-OCP\Share::registerBackend('gallery', 'OCA\Gallery\Share\Gallery', 'picture');


### PR DESCRIPTION
You have removed your personal classes e.g. OCA\Thumbnails. This causes some errors in the log file! There is no hook anymore in your app same for registering an individual backend
