### PR TITLE
gallery: don't display a spinner forever if empty

### DIFF
--- a/js/gallery.js
+++ b/js/gallery.js
@@ -207,7 +207,7 @@ Gallery.view.pushBreadCrumb = function (text, path) {
 Gallery.showEmpty = function () {
 	$('#controls').addClass('hidden');
 	$('#emptycontent').removeClass('hidden');
-	$('#loading').addClass('hidden');
+	$('#content').removeClass('icon-loading');
 };
 
 Gallery.showLoading = function () {


### PR DESCRIPTION
f9d952d broke this - it adjusted showLoading and showNormal for the spinner but forgot to adjust showEmpty, so when the gallery is empty, you see a spinner forever.
