### PR TITLE
Fix public sharing

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -21,5 +21,5 @@ $this->create('gallery_ajax_thumbnail', 'ajax/thumbnail')
 $this->create('gallery_ajax_batch', 'ajax/thumbnail/batch')
 	->actionInclude('gallery/ajax/batch.php');
 
-$this->create('gallery_public', '/public/{token}')
+$this->create('gallery_public', '/public/{t}')
 	->actionInclude('gallery/public.php');

--- a/public.php
+++ b/public.php
@@ -25,7 +25,7 @@
 OCP\Util::addStyle('gallery', 'styles');
 OCP\Util::addStyle('gallery', 'mobile');
 
-$token = \OC::$server->getRequest()->getParam('token');
+$token = isset($_GET['t']) ? (string)$_GET['t'] : '';
 
 if ($token) {
 	$linkItem = \OCP\Share::getShareByToken($token, false);


### PR DESCRIPTION
Public sharing was broken because the legacy router passes those values as `$_GET` which has to be accessed this way in this situation.

Furthermore this makes legacy links work again as they used  `t` instead of `token`

Needs a backport to stable8.

Fixes https://github.com/owncloud/gallery/issues/162 and https://github.com/owncloud/gallery/issues/160

@icewind1991 @karlitschek Please review.
