### PR TITLE
replace logo-wide on share page with better icon + text, as in core

### DIFF
--- a/templates/public.php
+++ b/templates/public.php
@@ -3,13 +3,23 @@
 <header>
 	<div id="header">
 		<a href="<?php print_unescaped(link_to('', 'index.php')); ?>"
-			title="" id="owncloud">
-			<div class="logo-wide svg">
-				<h1 class="hidden-visually">
-					<?php p($theme->getName()); ?>
-				</h1>
+		   title="" id="owncloud">
+			<div class="logo-icon svg">
 			</div>
 		</a>
+
+		<div class="header-appname-container">
+			<h1 class="header-appname">
+				<?php
+					if(OC_Util::getEditionString() === '') {
+						p($theme->getName());
+					} else {
+						print_unescaped($theme->getHTMLName());
+					}
+				?>
+			</h1>
+		</div>
+
 		<div id="logo-claim" style="display:none;"><?php p($theme->getLogoClaim()); ?></div>
 		<div class="header-right">
 			<span id="details"><?php p($l->t('shared by %s', $_['displayName'])) ?></span>


### PR DESCRIPTION
According to https://github.com/owncloud/core/pull/16517 – please review @owncloud/designers @oparoz @icewind1991 @DeepDiver1975 
