### PR TITLE
[master] Verify if path exists before processing

### DIFF
--- a/ajax/batch.php
+++ b/ajax/batch.php
@@ -27,6 +27,9 @@ if (!empty($_GET['token'])) {
 	OC_Util::setupFS($user);
 
 	$root = \OC\Files\Filesystem::getPath($linkItem['file_source']) . '/';
+	if($root === null) {
+		exit();
+	}
 	$images = array_map(function ($image) use ($root) {
 		return $root . $image;
 	}, $images);

--- a/ajax/getimages.php
+++ b/ajax/getimages.php
@@ -28,6 +28,9 @@ if (isset($_GET['token'])) {
 
 		// The token defines the target directory (security reasons)
 		$path = \OC\Files\Filesystem::getPath($linkItem['file_source']);
+		if($path === null) {
+			exit();
+		}
 
 		$view = new \OC\Files\View(\OC\Files\Filesystem::getView()->getAbsolutePath($path));
 		$images = $view->searchByMime('image');

--- a/ajax/image.php
+++ b/ajax/image.php
@@ -26,6 +26,9 @@ if (!empty($_GET['token'])) {
 	OC_User::setIncognitoMode(true);
 
 	$fullPath = \OC\Files\Filesystem::getPath($linkItem['file_source']);
+	if($fullPath === null) {
+		exit();
+	}
 	$img = trim($fullPath . '/' . $img);
 } else {
 	OCP\JSON::checkLoggedIn();

--- a/ajax/thumbnail.php
+++ b/ajax/thumbnail.php
@@ -27,6 +27,9 @@ if (!empty($_GET['token'])) {
 	OC_Util::setupFS($user);
 
 	$fullPath = \OC\Files\Filesystem::getPath($linkItem['file_source']);
+	if($fullPath === null) {
+		exit();
+	}
 	$img = trim($fullPath . '/' . $img);
 } else {
 	OCP\JSON::checkLoggedIn();


### PR DESCRIPTION
We need to verify if the specified path exists to prevent errors. To test this please ensure that in all legitim cases the public preview (i.e. the one you see when you have public shared galleries) does still work.

While exit() is here not the cleanest solution this is also what is used in other parts of the AJAX gallery code for error handling and I consider this thus a feasible solution for now.

@icewind1991 @PVince81 I'd appreciate if you could review these.
