### PR TITLE
Add auto incrementing id column to be used as a primary key.

### DIFF
--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -7,6 +7,14 @@
 	 <table>
 		<name>*dbprefix*pictures_images_cache</name>
 		<declaration>
+            <field>
+                <name>id</name>
+                <type>integer</type>
+                <default>0</default>
+                <notnull>true</notnull>
+                <autoincrement>1</autoincrement>
+                <length>4</length>
+            </field>
 			<field>
 				<name>uid_owner</name>
 				<type>text</type>
@@ -36,6 +44,14 @@
   <table>
     <name>*dbprefix*gallery_sharing</name>
     <declaration>
+      <field>
+        <name>id</name>
+        <type>integer</type>
+        <default>0</default>
+        <notnull>true</notnull>
+        <autoincrement>1</autoincrement>
+        <length>4</length>
+      </field>
       <field>
         <name>token</name>
         <type>text</type>


### PR DESCRIPTION
Galera replication requires all tables have a primary key. Manually adding an auto-incrementing column and setting it as the primary key has sufficed in the past. The new updater app (7.0.7 and possibly 7.0.6 too) is much more strict about db schema being different from the database.xml file. This fixes the issue.
